### PR TITLE
fix(k8s): codify LimeSurvey pod spec, raise app CPU 1→3 (stop admin-panel overload)

### DIFF
--- a/.github/workflows/gcr.yml
+++ b/.github/workflows/gcr.yml
@@ -33,3 +33,18 @@ jobs:
           gcloud auth configure-docker europe-west1-docker.pkg.dev
           docker build -t europe-west1-docker.pkg.dev/$GOOGLE_PROJECT/air-tools/limesurvey:${{ steps.get_tag.outputs.TAG }} .
           docker push europe-west1-docker.pkg.dev/$GOOGLE_PROJECT/air-tools/limesurvey:${{ steps.get_tag.outputs.TAG }}
+
+      # Enforce the pod spec (resources/replicas/HPA) from source, THEN roll the new image.
+      # Applying the manifest is what keeps cpu:3 from silently reverting to cpu:1 on deploy.
+      # Requires the deploy SA to have roles/container.developer on the cluster.
+      - name: Deploy to GKE
+        env:
+          GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
+          TAG: ${{ steps.get_tag.outputs.TAG }}
+        run: |
+          gcloud container clusters get-credentials limesurvey \
+            --region europe-west1 --project "$GOOGLE_PROJECT"
+          kubectl -n default apply -f deploy/k8s/limesurvey.yaml
+          kubectl -n default set image deployment/limesurvey \
+            "limesurvey-sha256-1=europe-west1-docker.pkg.dev/${GOOGLE_PROJECT}/air-tools/limesurvey:${TAG}"
+          kubectl -n default rollout status deployment/limesurvey --timeout=300s

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,0 +1,57 @@
+# LimeSurvey production deployment
+
+`limesurvey.yaml` is the **source of truth** for the production pod running
+`survey.air-tools.nl` (GKE Autopilot cluster `limesurvey`, project
+`air-tools-prod-1cca1`, namespace `default`).
+
+## Why this exists
+
+The Deployment was managed imperatively — the CI (`.github/workflows/gcr.yml`) only
+builds & pushes the image, and deploys were ad-hoc `kubectl set image`. Nothing stored
+the pod's resources/replicas, so hand-tuning during an incident **silently reverted** on
+the next deploy. The pod kept settling back to **cpu: 1** (a single Apache-throttled core),
+and under the France/Cint launch traffic that one pod pegged its core and the **admin panel
+(`/index.php/admin`) hung**.
+
+Codifying the spec here + applying it on every deploy makes the fix permanent.
+
+## The fix
+
+- App container CPU **1 → 3 cores** (fits the current `e2-standard-4` node — no cost jump).
+- Single replica by design: upload/config PVCs are **ReadWriteOnce** and Redis is an
+  **in-pod cache**, so we scale **vertically**, not horizontally. HPA is pinned min=max=1.
+  Horizontal scaling would first need RWX (Filestore) volumes + a shared/external Redis.
+
+## One-time: create the DB-password Secret
+
+The DB password used to be inline plaintext in the Deployment. It's now a Secret so the
+manifest is safe to commit. Create it once (value is the existing `DB_PASSWORD`):
+
+```bash
+kubectl -n default create secret generic limesurvey-secrets \
+  --from-literal=db-password='<CURRENT_DB_PASSWORD>'
+```
+
+(Grab the current value from the live pod if needed:
+`kubectl -n default get deploy limesurvey -o jsonpath='{range .spec.template.spec.containers[?(@.name=="limesurvey-sha256-1")].env[?(@.name=="DB_PASSWORD")]}{.value}{end}'`)
+
+## Deploy
+
+```bash
+gcloud container clusters get-credentials limesurvey --region europe-west1 --project air-tools-prod-1cca1
+kubectl -n default apply -f deploy/k8s/limesurvey.yaml
+# then roll the new image tag (CI does this automatically on a git tag):
+kubectl -n default set image deployment/limesurvey \
+  limesurvey-sha256-1=europe-west1-docker.pkg.dev/air-tools-prod-1cca1/air-tools/limesurvey:<TAG>
+kubectl -n default rollout status deployment/limesurvey
+```
+
+`strategy: Recreate` means ~30–90s of downtime on each rollout (the old pod releases the
+RWO disk before the new one starts). Expected.
+
+## Related (not managed here)
+
+- **Cloud SQL `limesurvey-v2`** is `db-g1-small` with `max_connections=1000` (memory-unsafe
+  for 1.7 GB). Not the active bottleneck today (Feb metrics: ~4% CPU, 11 conns) but worth
+  right-sizing to a dedicated-core tier and dropping `max_connections` to ~200 if the DB
+  becomes hot. Managed via `gcloud sql instances patch`, not this manifest.

--- a/deploy/k8s/limesurvey.yaml
+++ b/deploy/k8s/limesurvey.yaml
@@ -1,0 +1,156 @@
+# LimeSurvey production deployment (survey.air-tools.nl)
+# Cluster: air-tools-prod-1cca1 / GKE Autopilot "limesurvey" (europe-west1) / namespace default
+#
+# THIS FILE IS THE SOURCE OF TRUTH for the pod's shape (resources, replicas, HPA).
+# Deploys MUST `kubectl apply -f` this file so live changes can't silently drift.
+# History: the pod repeatedly reverted to cpu:1 (1 core) because nothing was codified —
+# under launch traffic (FR/Cint) a single throttled Apache pod pegs its core and the
+# admin panel hangs. See deploy/k8s/README.md.
+#
+# NOTE ON SCALE-OUT: the upload/config PVCs are ReadWriteOnce and Redis is an in-pod
+# cache, so this app is single-replica by design (strategy: Recreate, HPA min=max=1).
+# Capacity is scaled VERTICALLY (pod CPU), not horizontally. Horizontal scaling would
+# first require RWX (Filestore) volumes + an external/shared Redis.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: limesurvey
+  namespace: default
+  labels:
+    app: limesurvey
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: limesurvey
+  strategy:
+    type: Recreate            # RWO volumes: old pod must release the disk before the new one mounts
+  template:
+    metadata:
+      labels:
+        app: limesurvey
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values: ["europe-west1-d"]   # pinned to the zone of the RWO PVCs
+            - matchExpressions:
+              - key: cloud.google.com/extended-duration-pods
+                operator: In
+                values: ["1500m", "X"]
+      containers:
+      # ---- Redis (in-pod cache for LimeSurvey; NOT shared across pods) ----
+      - name: redis
+        image: redis:6.2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 6379
+          protocol: TCP
+        resources:
+          requests: { cpu: 250m, memory: 512Mi, ephemeral-storage: 1Gi }
+          limits:   { cpu: 250m, memory: 512Mi, ephemeral-storage: 1Gi }
+        securityContext:
+          capabilities:
+            drop: ["NET_RAW"]
+
+      # ---- LimeSurvey (Apache/PHP) ----
+      # CPU raised 1 -> 3 cores. This is the fix for the admin-panel overload:
+      # Apache runs up to 150 workers (MaxRequestWorkers) and was hard-capped at a single
+      # core. 3 cores fits the current e2-standard-4 Autopilot node (no node-size/cost jump).
+      - name: limesurvey-sha256-1
+        image: europe-west1-docker.pkg.dev/air-tools-prod-1cca1/air-tools/limesurvey:v0.0.109
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+          protocol: TCP
+        env:
+        - name: DB_HOST
+          value: "127.0.0.1"
+        - name: DB_NAME
+          value: "limesurvey"
+        - name: DB_USERNAME
+          value: "limesurvey"
+        - name: DB_PASSWORD                 # moved OUT of the manifest into a Secret (was inline plaintext)
+          valueFrom:
+            secretKeyRef:
+              name: limesurvey-secrets
+              key: db-password
+        - name: SERVER_NAME
+          value: "survey.air-tools.nl"
+        - name: CACHE_DRIVER
+          value: "redis"
+        - name: REDIS_HOST
+          value: "127.0.0.1"
+        - name: REDIS_PORT
+          value: "6379"
+        resources:
+          requests: { cpu: "3", memory: 4Gi, ephemeral-storage: 1Gi }
+          limits:   { cpu: "3", memory: 4Gi, ephemeral-storage: 1Gi }
+        securityContext:
+          capabilities:
+            drop: ["NET_RAW"]
+        volumeMounts:
+        - name: limesurvey-persistent-storage
+          mountPath: /var/www/html/upload
+        - name: limesurvey-config-persistent-storage
+          mountPath: /var/www/html/config2
+
+      # ---- Cloud SQL Auth Proxy (to limesurvey-v2) ----
+      - name: cloudsql-proxy
+        image: gcr.io/cloudsql-docker/gce-proxy:1.33.2
+        imagePullPolicy: IfNotPresent
+        command:
+        - /cloud_sql_proxy
+        - -instances=air-tools-prod-1cca1:europe-west1:limesurvey-v2=tcp:3306
+        - -credential_file=/secrets/cloudsql/key.json
+        resources:
+          requests: { cpu: 250m, memory: 512Mi, ephemeral-storage: 128Mi }
+          limits:   { cpu: 250m, memory: 512Mi, ephemeral-storage: 128Mi }
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 2
+          capabilities:
+            drop: ["NET_RAW"]
+        volumeMounts:
+        - name: cloudsql-instance-credentials
+          mountPath: /secrets/cloudsql
+          readOnly: true
+      volumes:
+      - name: limesurvey-persistent-storage
+        persistentVolumeClaim:
+          claimName: limesurvey-volumeclaim
+      - name: limesurvey-config-persistent-storage
+        persistentVolumeClaim:
+          claimName: limesurvey-config-volumeclaim
+      - name: cloudsql-instance-credentials
+        secret:
+          secretName: cloudsql-instance-credentials
+          defaultMode: 420
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: limesurvey
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: limesurvey
+  minReplicas: 1
+  maxReplicas: 1          # single-replica by design (RWO volumes + in-pod Redis). Do NOT raise
+                          # without first moving to RWX volumes + shared Redis.
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 80


### PR DESCRIPTION
## What & why

`survey.air-tools.nl`'s **admin panel repeatedly overloaded** under the France/Cint launch traffic. Root cause: the prod app pod was **hard-capped at 1 CPU** (Apache runs up to 150 workers on a single core → pegs it → the admin panel, which shares the pod, hangs).

**Why previous hotfixes kept reverting:** nothing was codified. CI only built/pushed the image; deploys were ad-hoc `kubectl set image`, and hand-tuned resources drifted back to `cpu:1`. There was no source of truth for the pod shape.

## Changes
- **`deploy/k8s/limesurvey.yaml`** — new source of truth (Deployment + HPA). App CPU **1 → 3 cores** (fits the current node; Autopilot bills per pod request). Single-replica by design (RWO upload/config PVCs + in-pod Redis → vertical scaling; `Recreate` strategy; HPA min=max=1).
- Moved the **inline plaintext `DB_PASSWORD`** out of the manifest into a Secret ref (`limesurvey-secrets`).
- **`.github/workflows/gcr.yml`** — after build/push, now `kubectl apply`s the manifest then rolls the image, so the spec is **enforced from source and can't silently drift** again.

## Already done live
The prod pod is **already running at cpu:3** (applied via `kubectl set resources`) and the site is healthy (admin 302 in ~0.4s). This PR makes that durable.

## ⚠️ Required before cutting the next release tag (or the CD step will fail)
1. Create the Secret the manifest references:
   ```
   kubectl -n default create secret generic limesurvey-secrets \
     --from-literal=db-password='<CURRENT_DB_PASSWORD>'
   ```
2. Grant the CI deploy service account **`roles/container.developer`** on the cluster.

See `deploy/k8s/README.md`.

## Follow-ups (not in this PR)
- Cloud SQL `limesurvey-v2` is `db-g1-small` with `max_connections=1000` (memory-unsafe on 1.7 GB) — right-size if it gets hot.
- No alerting on this box — add uptime + pod/SQL CPU alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)